### PR TITLE
Faster device search, better data handling, Get/Set Brightness

### DIFF
--- a/glow-control-lib/src/control_interface/mod.rs
+++ b/glow-control-lib/src/control_interface/mod.rs
@@ -551,7 +551,7 @@ impl ControlInterface {
         }
 
         // Send the packet for versions 1 and 2
-        return socket.send(&packet).await.map_err(|err| anyhow!(err));
+        socket.send(&packet).await.map_err(|err| anyhow!(err))
     }
     pub async fn show_rt_frame(&self, frame: &[u8]) -> anyhow::Result<()> {
         // Fetch the current mode from the device

--- a/glow-control-lib/src/control_interface/mod.rs
+++ b/glow-control-lib/src/control_interface/mod.rs
@@ -584,7 +584,8 @@ impl ControlInterface {
         socket.connect((self.host.as_str(), 7777)).await?;
         // Call the set_rt_frame_socket method to send the frame
         self.set_rt_frame_socket(&socket, frame, HardwareVersion::Version3)
-            .await.map_err(|err| anyhow!(err))
+            .await
+            .map_err(|err| anyhow!(err))
     }
 
     pub fn get_device_info(&self) -> &DeviceInfoResponse {
@@ -685,7 +686,9 @@ impl ControlInterface {
 
         // If the device is already on, we don't need to change the mode
         if current_mode != DeviceMode::Off {
-            return Ok(VerifyResponse { code: traits::OK.code });
+            return Ok(VerifyResponse {
+                code: traits::OK.code,
+            });
         }
 
         // If the device is off, set it to a default mode

--- a/glow-control-lib/src/control_interface/mod.rs
+++ b/glow-control-lib/src/control_interface/mod.rs
@@ -152,7 +152,11 @@ impl fmt::Display for DeviceMode {
 }
 
 impl ControlInterface {
-    pub async fn new(host: &str, hw_address: &str, existing_auth_token: Option<String>) -> anyhow::Result<Self> {
+    pub async fn new(
+        host: &str,
+        hw_address: &str,
+        existing_auth_token: Option<String>,
+    ) -> anyhow::Result<Self> {
         let client = Client::new();
 
         let auth_token: String = if let Some(given_auth_token) = existing_auth_token {
@@ -174,7 +178,9 @@ impl ControlInterface {
     }
 
     pub async fn reauthenticate(&mut self) -> bool {
-        if let Ok(result) = ControlInterface::authenticate(&self.client, &self.host, &self.hw_address).await {
+        if let Ok(result) =
+            ControlInterface::authenticate(&self.client, &self.host, &self.hw_address).await
+        {
             self.auth_token = result;
             true
         } else {

--- a/glow-control-lib/src/control_interface/mod.rs
+++ b/glow-control-lib/src/control_interface/mod.rs
@@ -37,7 +37,7 @@ pub enum HardwareVersion {
     Version3,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ControlInterface {
     pub host: String,
     hw_address: String,
@@ -147,6 +147,15 @@ impl ControlInterface {
             client,
             device_info,
         })
+    }
+
+    pub async fn reauthenticate(&mut self) -> bool {
+        if let Ok(result) = ControlInterface::authenticate(&self.client, &self.host, &self.hw_address).await {
+            self.auth_token = result;
+            true
+        } else {
+            false
+        }
     }
 
     /**

--- a/glow-control-lib/src/control_interface/mod.rs
+++ b/glow-control-lib/src/control_interface/mod.rs
@@ -1026,7 +1026,7 @@ pub struct TimerResponse {
     pub code: u32,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, Copy, Clone)]
 pub struct LedCoordinate {
     pub x: f64,
     pub y: f64,
@@ -1034,7 +1034,7 @@ pub struct LedCoordinate {
 }
 
 // Define a struct to deserialize the layout response
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, Clone)]
 pub struct LayoutResponse {
     pub source: String,
     pub synthesized: bool,

--- a/glow-control-lib/src/control_interface/mod.rs
+++ b/glow-control-lib/src/control_interface/mod.rs
@@ -668,6 +668,32 @@ impl ControlInterface {
         }
     }
 
+    /// Helper method to set the device brightness.
+    ///
+    /// # Arguments
+    /// - `brightness`: The brightness value to set.
+    ///                 Range is 0..100.
+    pub async fn set_brightness(&self, brightness: i32) -> anyhow::Result<()> {
+        let url = format!("http://{}/xled/v1/led/out/brightness", self.host);
+        let response = self
+            .client
+            .post(&url)
+            .header("X-Auth-Token", &self.auth_token)
+            .json(&json!({ "mode": "enabled", "type": "A", "value": brightness }))
+            .send()
+            .await
+            .context("Failed to set brightness")?;
+
+        if response.status() == StatusCode::OK {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "Failed to set the brightness with status: {}",
+                response.status()
+            ))
+        }
+    }
+
     async fn authenticate(client: &Client, host: &str, hw_address: &str) -> anyhow::Result<String> {
         // Generate a random challenge
         let challenge = Auth::generate_challenge();

--- a/glow-control-lib/src/util/discovery.rs
+++ b/glow-control-lib/src/util/discovery.rs
@@ -197,7 +197,7 @@ impl Discovery {
                         // Search if `existing_devices` matches a `discovery_response`:
                         if let Some(existing_devices) = &existing_devices {
                             if let Some(exist) =
-                                Self::find_discovered_device(&existing_devices, &discovery_response)
+                                Self::find_discovered_device(existing_devices, &discovery_response)
                             {
                                 found_existing_devices.insert(exist);
                                 info!("Device {:?} isn't new, skipping", discovery_response);

--- a/glow-control-lib/src/util/mod.rs
+++ b/glow-control-lib/src/util/mod.rs
@@ -3,3 +3,4 @@ pub mod discovery;
 pub mod rc4;
 
 pub mod movie;
+pub mod traits;

--- a/glow-control-lib/src/util/traits.rs
+++ b/glow-control-lib/src/util/traits.rs
@@ -1,0 +1,106 @@
+use serde::{Deserialize, Serialize};
+
+/// The response code for a command.
+///
+/// The HTTP Status in a response may
+/// only tell if a command could be error free received, but not if it was in any way valid
+/// and could be processed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct ResponseCode {
+    pub code: u32,
+    pub message: &'static str,
+}
+
+impl ResponseCode {
+    /// This is a code that means "Ok".
+    ///
+    /// Use this function instead of comparing the code to "1000",
+    /// it can be expanded if it becomes clearer (reverse-engineered) what other codes mean "Ok".
+    ///
+    /// That could be context-dependent.
+    pub fn is_ok(&self) -> bool {
+        self.code == OK.code
+    }
+
+    /// This is a code which means "Error".
+    pub fn is_error(&self) -> bool {
+        !self.is_ok()
+    }
+}
+
+// Errors codes from https://xled-docs.readthedocs.io/en/latest/rest_api.html#http-responses.
+
+/// The OK response code.
+pub const OK: ResponseCode = ResponseCode {
+    code: 1000,
+    message: "Ok",
+};
+/// An error response code.
+pub const ERROR: ResponseCode = ResponseCode {
+    code: 1001,
+    message: "Error",
+};
+/// An error response code.
+pub const ERROR_INVALID_ARGUMENT: ResponseCode = ResponseCode {
+    code: 1101,
+    message: "Invalid argument value",
+};
+/// An error response code.
+pub const ERROR2: ResponseCode = ResponseCode {
+    code: 1102,
+    message: "Error",
+};
+/// An error response code.
+pub const ERROR_VALUE_WRONG_MISSING_KEY: ResponseCode = ResponseCode {
+    code: 1103,
+    message: "Error - value too long? Or missing required object key?",
+};
+/// An error response code.
+pub const ERROR_MALFORMED_JSON_INPUT: ResponseCode = ResponseCode {
+    code: 1104,
+    message: "Error - malformed JSON on input?",
+};
+/// An error response code.
+pub const ERROR_INVALID_ARGUMENT_KEY: ResponseCode = ResponseCode {
+    code: 1105,
+    message: "Invalid argument key",
+};
+/// An OK response code?
+pub const OK2: ResponseCode = ResponseCode {
+    code: 1107,
+    message: "OK?",
+};
+/// An OK response code?
+pub const OK3: ResponseCode = ResponseCode {
+    code: 1108,
+    message: "OK?",
+};
+/// An error response code.
+pub const FIRMWARE_UPGRADE_ERROR: ResponseCode = ResponseCode {
+    code: 1205,
+    message: "Error with firmware upgrade - SHA1SUM does not match",
+};
+
+/// Trait for response codes.
+pub trait ResponseCodeTrait {
+    /// Get the response code.
+    /// # Returns
+    /// The response code.
+    fn response_code(&self) -> ResponseCode;
+
+    fn map_response_code(code: u32) -> ResponseCode {
+        match code {
+            1000 => OK,
+            1001 => ERROR,
+            1101 => ERROR_INVALID_ARGUMENT,
+            1102 => ERROR2,
+            1103 => ERROR_VALUE_WRONG_MISSING_KEY,
+            1104 => ERROR_MALFORMED_JSON_INPUT,
+            1105 => ERROR_INVALID_ARGUMENT_KEY,
+            1107 => OK2,
+            1108 => OK3,
+            1205 => FIRMWARE_UPGRADE_ERROR,
+            _ => ERROR,
+        }
+    }
+}

--- a/glow-control/src/main.rs
+++ b/glow-control/src/main.rs
@@ -211,7 +211,7 @@ async fn handle_cli(cli: Cli) -> Result<()> {
             }
         }
         Commands::DeviceCall { ip, mac, action } => {
-            let high_control_interface = ControlInterface::new(&ip, &mac).await?;
+            let high_control_interface = ControlInterface::new(&ip, &mac, None).await?;
 
             match action {
                 DeviceAction::GetMode => {


### PR DESCRIPTION
Hi,
your issue: #33, is something I have worked on.

* Because I just made some optimizations, so that devices which were already found, and are just in use, aren't reloaded when new devices are searched.
If a device which has already been loaded, and is just showing an animation, is reauthenticated, and data fetched from it, it will stutter horribly, ruining any animation. It will stutter a little bit for already responding to the search request, but not by that much if the whole Device-Loading and Authentication part is skipped.
All in all, **it speeds up the device discovery recognizable**, thanks also to now reusing the authentication-token from the device discovery.
* I also made it easier to reauthenticate.
* Added some derivatives to easier manipulate some data structures.
* Reading the `authentication_token_expires_in` field. While it's currently always the same, this may change in the future.
* Replaced the empty Result of `set_rt_frame_socket` with the actually written bytes, for better error detection.
* Setting and Getting the Brightness, which is essential, because if you have a big block of bright Twinkly lights, and the room hasn't walls and ceiling made out of glass, it's far too bright. The brightness-level must be reduced, individually for the room and daytime.
* Edit: I added a trait to check the result code, where Twinkly devices communicate not only if they received the message, but also if it was correct. Like "I could receive the message (HTTP Status Code 200), but the content was wrong (JSON Code Xyz)".

Normally I would've collected my changes longer, but since reading #33, I wanted to show you the results of my work now, and hope you consider them when working on #33.

@cgorski Thanks for the library, if you need any changes, please let me know.
